### PR TITLE
feat(dateTimePicker): remove date error if you change scope value

### DIFF
--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -103,6 +103,7 @@ angular.module('mgcrea.ngStrap.datepicker', [
         $datepicker.update = function (date) {
           // console.warn('$datepicker.update() newValue=%o', date);
           if (angular.isDate(date) && !isNaN(date.getTime())) {
+            controller.$setValidity('date', true);
             $datepicker.$date = date;
             $picker.update.call($picker, date);
           }

--- a/src/datepicker/test/datepicker.spec.js
+++ b/src/datepicker/test/datepicker.spec.js
@@ -1324,6 +1324,20 @@ describe('datepicker', function() {
       expect(scope.selectedDate).toBe('November 20, 2014');
     });
 
+   it('should trigger validation when scope value is set without datePicker', function() {
+      var elm = compileDirective('options-modelDateFormat');
+      // Should have the predefined value
+      expect(elm.val()).toBe('01/12/2014');
+      // Should correctly set the model value if set via the datepicker
+      elm.val('bonita');
+      angular.element(elm[0]).triggerHandler('change');
+
+      expect(angular.element(elm[0]).hasClass('ng-invalid')).toBeTruthy();
+      scope.selectedDate = '28/03/1991';
+      scope.$digest();
+
+      expect(angular.element(elm[0]).hasClass('ng-valid')).toBeTruthy();
+    });
   });
 
   describe('daysOfWeekDisabled', function() {

--- a/src/timepicker/test/timepicker.spec.js
+++ b/src/timepicker/test/timepicker.spec.js
@@ -1192,6 +1192,19 @@ describe('timepicker', function() {
 
       });
 
+      it('should trigger validation when scope value is set without timePicker', function() {
+        var elm = compileDirective('options-modelTimeFormat');
+        // Should have the predefined value
+        expect(elm.val()).toBe('12:20');
+        elm.val('bonita');
+        angular.element(elm[0]).triggerHandler('change');
+
+        expect(angular.element(elm[0]).hasClass('ng-invalid')).toBeTruthy();
+        scope.selectedTime = '18:20:10';
+        scope.$digest();
+
+        expect(angular.element(elm[0]).hasClass('ng-valid')).toBeTruthy();
+      });
     });
 
     describe('arrowBehavior', function() {

--- a/src/timepicker/timepicker.js
+++ b/src/timepicker/timepicker.js
@@ -104,6 +104,7 @@ angular.module('mgcrea.ngStrap.timepicker', ['mgcrea.ngStrap.helpers.dateParser'
         $timepicker.update = function (date) {
           // console.warn('$timepicker.update() newValue=%o', date);
           if (angular.isDate(date) && !isNaN(date.getTime())) {
+            controller.$setValidity('date',true);
             $timepicker.$date = date;
             angular.extend(viewDate, {
               hour: date.getHours(),


### PR DESCRIPTION
before if you set a right date by a external method the error validator are always here
Now we remove this error status because the new date will be correct
this issue was here because when we click on now or today button on dateTimePicker widget they don't refresh input validator status